### PR TITLE
nodjs-SimpleHTTPServer: Files are now loaded and sent in chunks

### DIFF
--- a/SimpleHTTPServer.js
+++ b/SimpleHTTPServer.js
@@ -50,6 +50,12 @@ http.createServer(function(request, response) {
 			} else if (stats.isDirectory()) {
 				fs.readdir(filePath, function(error, files) {
 					if (!error) {
+						files.sort(function(a, b) {
+							if (a.toLowerCase() < b.toLowerCase(ase()) return -1;
+								if (a.toLowerCase() > b.toLowerCase()) return 1;
+								return 0;
+						});
+																				
             			response.writeHead(200, {'Content-Type': 'text/html'});
             			response.write("<!DOCTYPE html>\n<html><head><meta charset='UTF-8'><title>" + filePath + "</title></head><body>");
             			response.write("<h1>" + filePath + "</h1>");

--- a/SimpleHTTPServer.js
+++ b/SimpleHTTPServer.js
@@ -46,7 +46,7 @@ http.createServer(function(request, response) {
 						var chunksize = 1024 * 1024
 						var position = 0;
 
-        				response.writeHead(200, {
+						response.writeHead(200, {
 							'Content-Length' : stats.size 
 						});
 
@@ -56,11 +56,11 @@ http.createServer(function(request, response) {
 							fs.read(fd, buffer, 0, chunksize, position, function (err, bytesRead) {
 								if(err) {
 									// TODO: error
-        							response.end();
+									response.end();
 									response.removeListener("drain", readFunc);
 								}
 								else if(bytesRead == 0) {
-        							response.end();
+									response.end();
 									response.removeListener("drain", readFunc);
 								}
 								else {
@@ -88,30 +88,30 @@ http.createServer(function(request, response) {
 							return 0;
 						});
 
-            			response.writeHead(200, {'Content-Type': 'text/html'});
-            			response.write("<!DOCTYPE html>\n<html><head><meta charset='UTF-8'><title>" + filePath + "</title></head><body>");
-            			response.write("<h1>" + filePath + "</h1>");
-            			response.write("<ul style='list-style:none;font-family:courier new;'>");
-					    files.unshift(".", "..");
+						response.writeHead(200, {'Content-Type': 'text/html'});
+						response.write("<!DOCTYPE html>\n<html><head><meta charset='UTF-8'><title>" + filePath + "</title></head><body>");
+						response.write("<h1>" + filePath + "</h1>");
+						response.write("<ul style='list-style:none;font-family:courier new;'>");
+						files.unshift(".", "..");
 						files.forEach(function(item) {
-						    var urlpath = pathname + item,
-						        itemStats = cachedStat.fileStatSync(current_dir + urlpath);
-						    if (itemStats.isDirectory()) {
-						        urlpath += "/";
-						        item += "/";
-						    }
+							var urlpath = pathname + item,
+								itemStats = cachedStat.fileStatSync(current_dir + urlpath);
+							if (itemStats.isDirectory()) {
+								urlpath += "/";
+								item += "/";
+							}
 							response.write("<li><a href='" + urlpath + "'>" + item + "</a></li>");
 						});
-            			response.end("</ul></body></html>");
+						response.end("</ul></body></html>");
 					} else {
-					    // Read dir error
-					    response.writeHead(500, {});
+						// Read dir error
+						response.writeHead(500, {});
 					}
 				});
 			}
 		} else {
-		    response.writeHead(404, {});
-		    response.end("File not found!");
+			response.writeHead(404, {});
+			response.end("File not found!");
 		}
 	});
 }).listen(port);

--- a/SimpleHTTPServer.js
+++ b/SimpleHTTPServer.js
@@ -34,7 +34,7 @@ var cachedStat = {
 http.createServer(function(request, response) {
 	var urlObject = urlParser.parse(request.url, true),
 		pathname = decodeURIComponent(urlObject.pathname);
-	console.log("[" + (new Date()).toUTCString() + "] " + '"' + request.method + " " + pathname + "\"");
+	console.log("[" + (new Date).toString() + "] " + request.connection.remoteAddress  + ': "' + request.method + " " + pathname + "\"");
 	
 	var filePath = path.join(current_dir, pathname);
 	cachedStat.fileStat(filePath, function(err, stats) {

--- a/SimpleHTTPServer.js
+++ b/SimpleHTTPServer.js
@@ -34,7 +34,7 @@ var cachedStat = {
 http.createServer(function(request, response) {
 	var urlObject = urlParser.parse(request.url, true),
 		pathname = decodeURIComponent(urlObject.pathname);
-	console.log("[" + (new Date).toString() + "] " + request.connection.remoteAddress  + ': "' + request.method + " " + pathname + "\"");
+	console.log("[" + (new Date()).toString() + "] " + request.connection.remoteAddress  + ': "' + request.method + " " + pathname + "\"");
 	
 	var filePath = path.join(current_dir, pathname);
 	cachedStat.fileStat(filePath, function(err, stats) {

--- a/SimpleHTTPServer.js
+++ b/SimpleHTTPServer.js
@@ -23,8 +23,8 @@ var cachedStat = {
             var cb = function(err, _stat) {
                 if (!err) {
                     cachedStat.table[fpath] = _stat;
-                    callback(err, _stat);
                 }
+                callback(err, _stat);
             };
             fs.stat(fpath, cb);
         }


### PR DESCRIPTION
Files now are loaded and sent in chunks, which gives two advantages:
- Smaller memory footprint, as only about one small part of the file has to reside in memory (especially important for files > 1 gb)
- Sending starts earlier, because the file doesn't need to be completely loaded from disk before sending

Although I'm using responses' drain event rather then sending the whole file as a block I wasn't able to measure a drop in speed, so there shouldn't be a noticeable impact on speed.
- some small bugfixes
